### PR TITLE
uniform(a,b) samples

### DIFF
--- a/src/grammar.pest
+++ b/src/grammar.pest
@@ -54,9 +54,9 @@ observe = { "observe" ~ "(" ~ expr ~ ")" ~ ";" }
 // Extra sampling statements
 bern = { identifier ~ "~" ~ "bern(" ~ expr ~ ")" ~ ";" }
 normal = { identifier ~ "~" ~ "normal(" ~ expr ~ "," ~ expr ~ ")" ~ ";" }
+uniform = { identifier ~ "~" ~ "uniform(" ~ expr ~ "," ~ expr ~ ")" ~ ";" }
 
-
-statement = _{ assignment | sample | branch | while_st | return_st | observe | bern | normal }
+statement = _{ assignment | sample | branch | while_st | return_st | observe | bern | normal | uniform }
 
 statement_list = { "{" ~ NEWLINE+ ~ (statement ~ NEWLINE+)+ ~ "}" }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -199,6 +199,19 @@ pub fn parse_statement(pair: Pair<Rule>, mut statement_counter: &mut u32) -> Sta
                 &mut statement_counter,
             )
         }
+        Rule::uniform => {
+            let mut inner_rules = pair.into_inner();
+
+            let var = inner_rules.next().unwrap().as_str().to_string();
+            let a = parse_expr(inner_rules.next().unwrap().into_inner());
+            let b = parse_expr(inner_rules.next().unwrap().into_inner());
+            let ret = Statement::(
+                StatementKind::Uniform(var, Expr::new(a), Expr::new(b)),
+                &mut statement_counter,
+                );
+                *statement_counter += ?; // Expand uniform statement later into ?+1 statements
+                ret
+        }
         Rule::branch => {
             let mut inner_rules = pair.into_inner();
 

--- a/src/semantics.rs
+++ b/src/semantics.rs
@@ -82,6 +82,7 @@ fn check_path_to_return(body: &[Statement]) -> bool {
         | StatementKind::Sample(_)
         | StatementKind::Bernoulli(_, _)
         | StatementKind::Normal(_, _, _)
+        | StatementKind::Uniform(_, _, _)
         | StatementKind::Observe(_) => false,
         StatementKind::Branch(_, true_branch, false_branch) => {
             check_path_to_return(&true_branch) && check_path_to_return(&false_branch)
@@ -132,6 +133,29 @@ impl Statement {
                 );
                 ensure!(
                     variance_t == Type::Real,
+                    SemanticsError::TypeError {
+                        expected: Type::Real,
+                        found: Type::Bool,
+                        e: variance.to_owned(),
+                    }
+                );
+
+                gamma.insert(&name, Type::Real);
+            }
+            StatementKind::Uniform(name, a, b) => {
+                let a_t = mean.typecheck(fn_sigs, gamma)?;
+                let b_t = variance.typecheck(fn_sigs, gamma)?;
+
+                ensure!(
+                    a_t == Type::Real,
+                    SemanticsError::TypeError {
+                        expected: Type::Real,
+                        found: Type::Bool,
+                        e: mean.to_owned(),
+                    }
+                );
+                ensure!(
+                    b_t == Type::Real,
                     SemanticsError::TypeError {
                         expected: Type::Real,
                         found: Type::Bool,

--- a/src/syntax.rs
+++ b/src/syntax.rs
@@ -107,6 +107,7 @@ pub enum StatementKind {
     Sample(String),
     Bernoulli(String, Expr),
     Normal(String, Expr, Expr),
+    Uniform(String, Expr, Expr),
     Branch(Expr, Vec<Statement>, Vec<Statement>),
     While(Expr, Vec<Statement>),
     Return(Expr),


### PR DESCRIPTION
should be encoded as `x_i ~ rnd(); x_i := x_i*(b-a)+a`
maybe I saved you a little work; no way of testing it meself